### PR TITLE
Issue #1 - Added filters option to restrict jquery-oauth to an url/domain.

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,6 +57,17 @@ define([/*other dependencies,*/ "jquery-oauth", function(jqOAuth){
 
 	var auth = new jqOAuth({
         csrfToken: csrfToken,
+        tokenName : 'WebServiceUsingOauth' ,
+            // Optional. You might want to set a name for your jquery-oauth instance if
+            // you intend on having multiple instances for multiple web services.
+            // This name will be used for store.js's storage. 
+        filters: {
+            url : function(url) {
+                // The ajax's request url is received to determine whether or not
+                // the Authorization header should be added.
+                // Returning true will add the header.
+            }
+        },
         events: {
             login: function() {
                 // User is hereby logged in and the 

--- a/src/jquery.oauth.js
+++ b/src/jquery.oauth.js
@@ -161,14 +161,16 @@ jqOAuth.prototype._setupInterceptor = function _setupInterceptor() {
 
     // Credits to gnarf @ http://stackoverflow.com/a/12446363/602488
     $.ajaxPrefilter(function(options, originalOptions, jqxhr) {
-        if (!self._shouldAddAuthorization(options)) {
-            return;
+        if (self._shouldAddAuthorization(options)) {
+            jqxhr.setRequestHeader('Authorization', 'Bearer ' + self.data.accessToken);
         }
-
-        jqxhr.setRequestHeader('Authorization', 'Bearer ' + self.data.accessToken);
 
         if (self._hasCSRFToken()) {
             jqxhr.setRequestHeader('X-CSRF-Token', this.options.csrfToken);
+        }
+
+        if (options.refreshRetry === true) {
+            return;
         }
 
         var deferred = $.Deferred();
@@ -214,7 +216,7 @@ jqOAuth.prototype._setupInterceptor = function _setupInterceptor() {
 };
 
 jqOAuth.prototype._shouldAddAuthorization = function _shouldAddAuthorization(prefilterOptions) {
-    return prefilterOptions.refreshRetry !== false && (!this._hasFilter('url') || this.options.filters.url(prefilterOptions.url));
+    return !this._hasFilter('url') || this.options.filters.url(prefilterOptions.url);
 };
 
 jqOAuth.prototype._updateStorage = function _updateStorage() {


### PR DESCRIPTION
#1 
-Modified readme to include tokenName and filters
-Modified the interceptor so it adds the Authorize/csrf headers on the fly and not when setting the tokens.
-Added the filters options to filter out urls that shouldn't have an Authorize tags.